### PR TITLE
로그인 api 연결, token 유무에 따른 페이지 이동 구현

### DIFF
--- a/front-end/src/pages/Login.tsx
+++ b/front-end/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import useMakeEmail from "../hooks/useMakeEmail";
 import useMakePassWord from "../hooks/useMakePassWord";
 import { useNavigate } from "react-router-dom";
@@ -8,6 +8,12 @@ export default function Login() {
   const { userPassWord, isConfirmPassWord, handlePassWordInput } =
     useMakePassWord();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (localStorage.getItem("userToken")) {
+      navigate("/todo");
+    }
+  });
 
   async function handleSignIn() {
     await fetch("https://www.pre-onboarding-selection-task.shop/auth/signin", {

--- a/front-end/src/pages/Login.tsx
+++ b/front-end/src/pages/Login.tsx
@@ -1,11 +1,34 @@
 import React from "react";
 import useMakeEmail from "../hooks/useMakeEmail";
 import useMakePassWord from "../hooks/useMakePassWord";
+import { useNavigate } from "react-router-dom";
 
 export default function Login() {
   const { userEmail, isConfirmEmail, handleEmailInput } = useMakeEmail();
   const { userPassWord, isConfirmPassWord, handlePassWordInput } =
     useMakePassWord();
+  const navigate = useNavigate();
+
+  async function handleSignIn() {
+    await fetch("https://www.pre-onboarding-selection-task.shop/auth/signin", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: userEmail, password: userPassWord }),
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.access_token) {
+          localStorage.setItem("userToken", data.access_token);
+          alert("로그인되었습니다.");
+          navigate("/todo");
+        } else throw data.message;
+      })
+      .catch((error) =>
+        alert(`로그인 중 에러가 발생했습니다. \n에러내용: ${error}`)
+      );
+  }
 
   return (
     <div>
@@ -27,6 +50,7 @@ export default function Login() {
           data-testid="signin-button"
           type="button"
           disabled={!(isConfirmEmail && isConfirmPassWord)}
+          onClick={handleSignIn}
         >
           로그인
         </button>

--- a/front-end/src/pages/SignUp.tsx
+++ b/front-end/src/pages/SignUp.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import useMakeEmail from "../hooks/useMakeEmail";
 import useMakePassWord from "../hooks/useMakePassWord";
 import { useNavigate } from "react-router-dom";
@@ -9,6 +9,12 @@ export default function SignUp() {
     useMakePassWord();
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (localStorage.getItem("userToken")) {
+      navigate("/todo");
+    }
+  });
 
   async function handleSignUp() {
     await fetch("https://www.pre-onboarding-selection-task.shop/auth/signup", {


### PR DESCRIPTION
## 개요
로그인 api 연결, token 유무에 따른 페이지 이동 구현

## 작업 사항
- 로그인 api를 연결했어요.
- localStorage에 userToken 이 있는 상태로 로그인, 회원가입 페이지로 이동하면 /todo url로 이동할 수 있게 했어요.
