### PR TITLE
/signin 경로로 리다이렉트, todo의 체크박스 클릭 시 서버 반영 PR

### DIFF
--- a/front-end/src/components/Todo.tsx
+++ b/front-end/src/components/Todo.tsx
@@ -81,6 +81,9 @@ export default function Todo({ todo, fetchReadTodoList }: TodoType) {
               type="checkbox"
               checked={isCompleted}
               onChange={handleTodoCheckBox}
+              onClick={(event) =>
+                fetchUpdateTodo(editTodo, event.currentTarget.checked)
+              }
             />
             <span>{todo.todo}</span>
           </label>

--- a/front-end/src/pages/TodoPage.tsx
+++ b/front-end/src/pages/TodoPage.tsx
@@ -1,12 +1,20 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import useMakeUserTodo from "../hooks/useMakeUserTodo";
 import TodoList from "../components/TodoList";
 import { TodoListType } from "../types/todoList.type";
 
 export default function TodoPage() {
+  const navigate = useNavigate();
   const { userTodo, handleUserTodo } = useMakeUserTodo();
   const [todoList, setTodoList] = useState<TodoListType[]>([]);
   const userToken = localStorage.getItem("userToken");
+
+  useEffect(() => {
+    if (!localStorage.getItem("userToken")) {
+      navigate("/signin");
+    }
+  });
 
   useEffect(fetchReadTodoList, []);
 


### PR DESCRIPTION
## 개요
/signin 경로로 리다이렉트, todo의 체크박스 클릭 시 서버 반영 PR

## 작업 사항
- todo의 체크박스 클릭 시 서버 todoList의 isCompleted에 반영될 수 있게 했어요
  (체크박스 클릭하면 새로고침 하더라도 완료한 상태로 변경됨)
- localStorage에 토큰이 없는 상태로 /todo 접속 시 /signin 경로로 리다이렉트 될 수 있게 했어요. 