### PR TITLE
todo 수정 시 input checkbox 연동되지 않음 수정

### DIFF
--- a/front-end/src/components/Todo.tsx
+++ b/front-end/src/components/Todo.tsx
@@ -72,6 +72,7 @@ export default function Todo({ todo, fetchReadTodoList }: TodoType) {
       {isEditTodoState ? (
         <UpdateTodo
           setIsEditTodoState={setIsEditTodoState}
+          serverIsCompleted={isCompleted}
           serverTodo={editTodo}
           fetchUpdateTodo={fetchUpdateTodo}
         />

--- a/front-end/src/components/UpdateTodo.tsx
+++ b/front-end/src/components/UpdateTodo.tsx
@@ -5,20 +5,24 @@ import styled from "styled-components";
 
 type UpdateTodoType = {
   serverTodo: string | undefined;
+  serverIsCompleted: boolean;
   setIsEditTodoState: (state: boolean) => void;
   fetchUpdateTodo: (todo: string, isCompleted: boolean) => void;
 };
 
 export default function UpdateTodo({
   serverTodo,
+  serverIsCompleted,
   setIsEditTodoState,
   fetchUpdateTodo,
 }: UpdateTodoType) {
-  const { isCompleted, handleTodoCheckBox } = useMakeTodoCheckBox();
+  const { isCompleted, setIsCompleted, handleTodoCheckBox } =
+    useMakeTodoCheckBox();
   const { editTodo, setEditTodo, changeTodoInput } = useMakeEditTodoInput();
 
   useEffect(() => {
     serverTodo && setEditTodo(serverTodo);
+    setIsCompleted(serverIsCompleted);
   }, []);
 
   return (


### PR DESCRIPTION
## 개요
todo 수정 시 input checkbox 연동되지 않음 수정

## 작업 사항
- 이미 checkbox에 체크가 되어있는 상태로 수정버튼을 누르면 checkbox가 초기화 되는 현상을 수정했습니다.